### PR TITLE
Fix compilation for stable 9.0 release

### DIFF
--- a/IDA Pro SigMaker/Main.cpp
+++ b/IDA Pro SigMaker/Main.cpp
@@ -159,7 +159,7 @@ static std::vector<ea_t> FindSignatureOccurences( std::string_view idaSignature,
 	std::vector<ea_t> results;
 	auto ea = inf_get_min_ea();
 	while( true ) {
-		auto occurence = bin_search3( ea, inf_get_max_ea(), binaryPattern, BIN_SEARCH_NOCASE | BIN_SEARCH_FORWARD );
+		auto occurence = bin_search( ea, inf_get_max_ea(), binaryPattern, BIN_SEARCH_NOCASE | BIN_SEARCH_FORWARD );
 
 		// Signature not found anymore
 		if( occurence == BADADDR ) {


### PR DESCRIPTION
Looks like they renamed bin_search3 to just bin_search again in the stable release of the sdk